### PR TITLE
Capture HTTP `Last-Modified` as `mtime` in `Meta.from_info()`

### DIFF
--- a/src/dvc_data/hashfile/meta.py
+++ b/src/dvc_data/hashfile/meta.py
@@ -57,6 +57,14 @@ class Meta:
         ):
             checksum = info.get("ETag") or info.get("Content-MD5")
 
+        mtime = info.get("mtime")
+        if mtime is None and protocol and protocol.startswith("http"):
+            last_modified = info.get("Last-Modified")
+            if last_modified:
+                from email.utils import parsedate_to_datetime
+
+                mtime = parsedate_to_datetime(last_modified).timestamp()
+
         version_id = info.get("version_id")
         if protocol == "s3" and "VersionId" in info:
             version_id = info.get("VersionId")
@@ -73,7 +81,7 @@ class Meta:
             checksum,
             info.get("md5"),
             info.get("ino"),
-            info.get("mtime"),
+            mtime,
             info.get("remote"),
             info.get("islink", False),
             info.get("destination"),

--- a/tests/hashfile/test_meta.py
+++ b/tests/hashfile/test_meta.py
@@ -1,0 +1,44 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from dvc_data.hashfile.meta import Meta
+
+
+def test_from_info_http_last_modified():
+    info = {
+        "type": "file",
+        "size": 123,
+        "Last-Modified": "Wed, 21 Oct 2015 07:28:00 GMT",
+    }
+    meta = Meta.from_info(info, protocol="https")
+    expected = datetime(2015, 10, 21, 7, 28, 0, tzinfo=timezone.utc).timestamp()
+    assert meta.mtime == expected
+
+
+def test_from_info_http_mtime_takes_precedence_over_last_modified():
+    info = {
+        "type": "file",
+        "size": 123,
+        "mtime": 1000.0,
+        "Last-Modified": "Wed, 21 Oct 2015 07:28:00 GMT",
+    }
+    meta = Meta.from_info(info, protocol="http")
+    assert meta.mtime == 1000.0
+
+
+def test_from_info_http_no_last_modified():
+    info = {"type": "file", "size": 123}
+    meta = Meta.from_info(info, protocol="https")
+    assert meta.mtime is None
+
+
+@pytest.mark.parametrize("protocol", ["s3", "gs", "azure", "local", None])
+def test_from_info_last_modified_ignored_for_non_http(protocol):
+    info = {
+        "type": "file",
+        "size": 123,
+        "Last-Modified": "Wed, 21 Oct 2015 07:28:00 GMT",
+    }
+    meta = Meta.from_info(info, protocol=protocol)
+    assert meta.mtime is None


### PR DESCRIPTION
`Meta.from_info()` now parses the `Last-Modified` header from HTTP responses into the `mtime` field (as a Unix timestamp). Uses stdlib `email.utils.parsedate_to_datetime` for RFC 2822 date parsing.

`to_dict()` intentionally does NOT serialize `mtime`, because DVC's schema validation doesn't include it and adding it would break `dvc add` for local files (which always have filesystem mtime set). Consumers that want to persist HTTP `mtime` need to handle serialization themselves.

### Motivation

[DVX] (a fork of DVC) uses this for `dvx import-url --git`: the HTTP `Last-Modified` timestamp gets stored in `.dvc` files so `dvx update` can detect remote changes without re-downloading. Currently DVX vendors this as a monkeypatch; if upstream accepts it, DVX can drop the patch.

[DVX]: https://github.com/runsascoded/dvx