### PR TITLE
CI: split lint into separate job (run once instead of 18× per-matrix-cell)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+    - uses: astral-sh/setup-uv@v7
+      with:
+        enable-cache: true
+        cache-suffix: lint
+        cache-dependency-glob: pyproject.toml
+
+    - name: Install nox
+      run: uv pip install --system nox --upgrade
+
+    - name: Cache pre-commit hooks
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
+    - name: Lint code
+      run: nox -s lint
+
   tests:
+    needs: [lint]
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
@@ -40,17 +73,9 @@ jobs:
         enable-cache: true
         cache-suffix: ${{ matrix.pyv }}
         cache-dependency-glob: pyproject.toml
+
     - name: Install nox
       run: uv pip install --system nox --upgrade
-
-    - name: Cache pre-commit hooks
-      uses: actions/cache@v5
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
-
-    - name: Lint code
-      run: nox -s lint
 
     - name: Run tests
       run: nox -s tests-${{ matrix.pyv }} -- --cov-report=xml
@@ -63,7 +88,7 @@ jobs:
 
   check:
     if: always()
-    needs: [tests]
+    needs: [lint, tests]
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@release/v1


### PR DESCRIPTION
## What

Extract `nox -s lint` from the test matrix into its own dedicated job.

## Why

The current workflow runs `nox -s lint` inside every test matrix cell: 3 OS × 6 Python versions = **18 redundant lint runs** per CI trigger. Lint is platform- and Python-version-independent, so it only needs to run once.

## Change

- New `lint` job: ubuntu-latest, Python 3.12, runs once
- `tests` job now `needs: [lint]` — no point running 18 expensive test cells if lint is broken
- `check` job updated to `needs: [lint, tests]`
- `fail-fast: false` preserved on the test matrix — platform-specific failures (e.g. Windows-only) remain fully visible

No test logic changes; just moving `nox -s lint` + its pre-commit cache out of the matrix.